### PR TITLE
匿名成员取出来平铺

### DIFF
--- a/api/com/parser/api_parser_scan.go
+++ b/api/com/parser/api_parser_scan.go
@@ -954,6 +954,21 @@ func parseType(
 
 			}
 
+			if tField.Anonymous() {
+				fieldType := parseType(info, tField.Type())
+				fieldStruct, ok := fieldType.(*StructType)
+				if !ok {
+					logrus.Warnf("anonymous field:%s must be struct", tField)
+					continue
+				}
+				//匿名成员取出来平铺
+				if err := structType.AddFields(fieldStruct.Fields...); err != nil {
+					logrus.Warnf("parse struct type add fields failed. error: %s.", err)
+					return
+				}
+				continue
+			}
+
 			// tags
 			field.Tags = parseStringTagParts(tStructType.Tag(i))
 

--- a/api/com/parser/api_parser_swagger_test.go
+++ b/api/com/parser/api_parser_swagger_test.go
@@ -1,13 +1,14 @@
 package parser
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
 
 func TestSaveApisSwaggerSpec(t *testing.T) {
 	swgSpc := NewSwaggerSpec()
-	swgSpc.Apis(nil, []*ApiItem{
+	swgSpc.Apis([]*ApiItem{
 		{
 			ApiItemParams: ApiItemParams{
 				HeaderData: &StructType{
@@ -59,6 +60,40 @@ func TestSaveApisSwaggerSpec(t *testing.T) {
 	}
 
 	out, err := swgSpc.Output()
+	if nil != err {
+		t.Error(err)
+		return
+	}
+
+	fmt.Println(string(out))
+}
+
+func TestSaveApisSwaggerSpec2(t *testing.T) {
+	_, a, err := ParseApis(
+		"/data/apps/go/video_buddy_share/manage/api/share",
+		true,
+		false,
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(a[0])
+
+	swgSpc := NewSwaggerSpec()
+	swgSpc.Apis(a)
+	swgSpc.Info(
+		"Book shop",
+		"book shop api for testing tools",
+		"1",
+		"haozzzzzzzz",
+	)
+	err = swgSpc.ParseApis()
+	if nil != err {
+		t.Error(err)
+		return
+	}
+
+	out, err := json.Marshal(swgSpc.Swagger) //goland输出控制台->右键->Show as JSON
 	if nil != err {
 		t.Error(err)
 		return


### PR DESCRIPTION
bug描述：
匿名成员解析有些问题，例如解析请求的body参数postData：
```go
postData := struct {
	A
	S string `json:"s"`
}{}
```
匿名A结构：
```go
type A struct {
	I int `json:"i"`
}
```
解析出来是：
```json
{
  "": {
    "i": 0
  },
  "s": "string"
}
```
修复之后解析成：
```json
{
  "i": 0,
  "s": "string"
}
```